### PR TITLE
Pasargad xml to pem key conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@keivan.sf/rsa-xml": "^0.1.1",
     "axios": "^0.27.2",
     "crc-32": "^1.2.2",
     "crypto-js": "^4.1.1",

--- a/src/drivers/pasargad/api.ts
+++ b/src/drivers/pasargad/api.ts
@@ -177,18 +177,10 @@ export type RequestOptions = z.infer<typeof requestSchema>;
 
 export const configSchema = baseConfigSchema.extend({
   /**
-   * This is your **RSA private key** in `pem` format.
-   *
-   * You are likely to have an `xml` version of your key due to Pasargad providing a `certificate.xml` file.
-   * In order to use this method you must convert it to `pem` format and provide the private key as pem for this field.
-   *
-   * To convert xml into pem you may use an rsa-xml to rsa-pem library or use {@link https://github.com/pepco-api pasargad sdk's code} for it
-   *
-   * You can turn to online convertors as well if it's not a matter of security
-   *
-   * - Make sure you have the correct key (by converting it to xml again and comparing the results with the actual xml version)
+   * Your **RSA** Private key file path.
+   * File must be in `XML` format
    */
-  privateKey: z.string(),
+  privateKeyXMLFile: z.string(),
   merchantId: z.string(),
   terminalId: z.string(),
 });

--- a/src/drivers/pasargad/pasargad.spec.ts
+++ b/src/drivers/pasargad/pasargad.spec.ts
@@ -1,21 +1,27 @@
 import axios from 'axios';
-import * as crypto from 'crypto';
+import * as fs from 'fs/promises';
 import { getPaymentDriver } from '../../drivers';
 import { RequestException, VerificationException } from '../../exceptions';
 import * as API from './api';
 import { Pasargad } from './pasargad';
 
 jest.mock('axios');
+jest.mock('fs/promises');
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockKey = `<RSAKeyValue>
+<Modulus>n2qWKhU63oMvcp3eVVLFtrnZjZdOzgjvqeogl/ruXCaMAVd7hrJQpYpcEt37P15spDCiyVR3OE8wjLaDDb8PktrxvovZ8t126vrN3xDuxUdt0MrBx5yYfwNCqRnc2DGKi+SiQgj3TjIZ1rF6R7ia/WNYJVbutp2+ORzYtufCkgE=</Modulus>
+<Exponent>AQAB</Exponent>
+<P>rhWXibYPWhZ6ekpb/8UWSt5eY1Z8sx+XDDNiEYFYplgmOi9jwAf5h/88W0ywduBjiMr8Ov9v7IPIzyYBLyzhGw==</P>
+<Q>6m4SMV9fcvE95Wcwzn32gM+71Lbl4gQVkz4gXjjB8IDynAqE8WVnVzEFwS6+XXNv4pW+xf7rzjtm73G2NFRnEw==</Q>
+<DP>pjgXqXYc0ngEGiBGF8Gnt3T7yv4Zsy7Gmu+1A+HtM2eXmJcHN6RlrmUWzFY9aER4xXSLwgmEZOCwLJqtJs5DYQ==</DP>
+<DQ>Ilm8mrVx5ALLYgjr0uYML7XAvRuLtcGJc8jfr067xETwx8KW1lRYfyM0x6jUxha7J0Vv7c07uj1kCOPtod9YNw==</DQ>
+<InverseQ>XV7UhJDUxqFDaS6uMpXA64tlvsfvFWlVqO1fRsOC/Gv90xLoqYEL4PUe9y4dmtfwmubb50egak7okmwCgljYHw==</InverseQ>
+<D>io7Xyef97NzU5qg0ULDKzBEo+BolEotN0799aNtfRZTzZ08kPGTMF7X0ZSmvcNqfTu4+7wKNRNH/fq47pj0ESNsWVt1FkQu/upp6uTzdiFF2xjcouA8NCLhdV1/VJjtINJq3M8AUT8Qa5VvDTbzL5bxyvWfIqxZVWU0k7XGEVak=</D>
+</RSAKeyValue>`;
 
-const mockedKeyPair = crypto.generateKeyPairSync('rsa', {
-  modulusLength: 1024,
-});
-const mockedPemKey = mockedKeyPair.privateKey.export({
-  format: 'pem',
-  type: 'pkcs8',
-}) as string;
+mockedFs.readFile.mockResolvedValue(Buffer.from(mockKey));
 
 describe('Pasargad', () => {
   it('returns the correct payment url', async () => {
@@ -26,7 +32,7 @@ describe('Pasargad', () => {
     };
     mockedAxios.post.mockResolvedValueOnce({ data: getTokenResponse });
     const driver = getPaymentDriver<Pasargad>('pasargad', {
-      privateKey: mockedPemKey,
+      privateKeyXMLFile: './something.xml',
       merchantId: '123',
       terminalId: '123',
     });
@@ -50,7 +56,7 @@ describe('Pasargad', () => {
     };
     mockedAxios.post.mockResolvedValueOnce({ data: getTokenResponse });
     const driver = getPaymentDriver<Pasargad>('pasargad', {
-      privateKey: mockedPemKey,
+      privateKeyXMLFile: './something.xml',
       merchantId: '123',
       terminalId: '123',
     });
@@ -82,7 +88,7 @@ describe('Pasargad', () => {
     mockedAxios.post.mockResolvedValueOnce({ data: serverResponse });
 
     const driver = getPaymentDriver<Pasargad>('pasargad', {
-      privateKey: mockedPemKey,
+      privateKeyXMLFile: './something.xml',
       merchantId: '123',
       terminalId: '123',
     });
@@ -99,7 +105,7 @@ describe('Pasargad', () => {
     };
     mockedAxios.post.mockResolvedValueOnce({ data: verifyPaymentResponse });
     const driver = getPaymentDriver<Pasargad>('pasargad', {
-      privateKey: mockedPemKey,
+      privateKeyXMLFile: './something.xml',
       merchantId: '123',
       terminalId: '123',
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,6 +900,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@keivan.sf/rsa-xml@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@keivan.sf/rsa-xml/-/rsa-xml-0.1.1.tgz#d6ac7293aaa6b613f50017454e0992aad99bd111"
+  integrity sha512-5yKc7VPY2N1or1ATvQdhhXkvxO5f4oY0zWRwBl12VYcBYGS/DWBlvCHR7vZBSaQm3I3nG4q/5ZlVGUc3V6vMPg==
+  dependencies:
+    asn1 "^0.2.3"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1245,6 +1252,13 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+asn1@^0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -3051,6 +3065,11 @@ safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sax@>=0.6:
   version "1.2.4"


### PR DESCRIPTION
resolves #24 
Pasargad driver now accepts the users private key in rsa xml format (The format which the bank provides the developers with)

I've tested the signature verification in `c#` , the only place xml is actually common for rsa, to make sure we're not missing any thing in the process of conversion.

The package I've used is [rsa-xml](https://github.com/codeforce-dev/rsa-xml) , which does not provide any types and default exports. I've notified the developer in a pull request but we can't be waiting due to the code being too old and probably never meant to be updated. Therefore I've decided to create an npm fork myself to include declaration files and make the necessary export changes.
Fork page: [@keivan.sf/rsa-xml](https://www.npmjs.com/package/@keivan.sf/rsa-xml)

The tests were modified to satisfy the changes