### PR TITLE
Disable eslint banning ts comment rule for test files

### DIFF
--- a/src/driver.spec.ts
+++ b/src/driver.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { BadConfigError } from './exceptions';
 import { z } from 'zod';
 import { defineDriver } from './driver';


### PR DESCRIPTION
This simply will let us simulate a js user in test files to be sure our validation/parsing process is working properly
resolves #40 