### PR TITLE
fix: timeFormat Func in behpardakht driver

### DIFF
--- a/src/drivers/behpardakht/index.ts
+++ b/src/drivers/behpardakht/index.ts
@@ -104,7 +104,7 @@ export class Behpardakht extends Driver<API.Config> {
    */
   timeFormat(date = new Date()) {
     const hh = date.getHours();
-    const mm = date.getMonth();
+    const mm = date.getMinutes();
     const ss = date.getSeconds();
     return hh.toString() + mm.toString() + ss.toString();
   }


### PR DESCRIPTION
Bugfix date.getMonth to date.getMinutes in timeFormat Func.